### PR TITLE
Fix Modern React testing, part 2: Jest and Enzyme

### DIFF
--- a/content/en/all/react-testing-2-jest-and-enzyme.md
+++ b/content/en/all/react-testing-2-jest-and-enzyme.md
@@ -283,7 +283,7 @@ Here we’re testing that our `Pizza` component renders all ingredients passed t
 
 ### Testing user interaction
 
-To “simulate” (see “To `simulate()` or not” above) an event like `click` or `change`, call this event’s prop directly and then test the output:
+To “simulate” (see “To `simulate()` or not” above) an event like `click` or `change`, call the `simulate` method and then test the output:
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
You are not calling the event's prop directly in the code listing below. It's a little related to https://github.com/sapegin/blog.sapegin.me/issues/21.