### PR TITLE
change reference to `@supports` with reference to `any-hover`

### DIFF
--- a/content/all/accessibility-testing.md
+++ b/content/all/accessibility-testing.md
@@ -179,7 +179,7 @@ A few more things that are worth testing:
 
 - **Hover alternatives** for keyboard and touchscreens: hover shouldn’t be the only way to reveal some content or an interactive element. A common example is a menu that appears on hover on an item in a long list. [A tooltip](https://inclusive-components.design/tooltips-toggletips/) is another example. We could show these elements when the container is in focus for keyboard users, and always show them on touchscreens.
 
-**Tip** Use CSS [`@supports`](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) at-rule to test hover support on the device.
+**Tip** Use CSS [`any-hover`](https://www.w3.org/TR/mediaqueries-4/#any-input) interaction media feature query to test hover support on the device - though beware of making [incorrect assumptions](https://css-tricks.com/interaction-media-features-and-their-potential-for-incorrect-assumptions/).
 
 **Tip:** We could you Cypress and cypress-axe [to test the accessibility of our site or app in the dark mode](https://www.cypress.io/blog/2019/12/13/test-your-web-app-in-dark-mode/).
 


### PR DESCRIPTION
Unless I'm missing something, `@supports` has nothing that would inform you about a device's ability/inability to provide hover. Assume this meant to reference `@media (any-hover: hover)`. And, while admittedly self-promotional, added reference to my article about using those hints with caution.